### PR TITLE
Add the ability to update the triggering record

### DIFF
--- a/src/dotnet-core/Wexflow.Tasks.WorkiomUpdateRecord/WorkiomUpdateRecord.cs
+++ b/src/dotnet-core/Wexflow.Tasks.WorkiomUpdateRecord/WorkiomUpdateRecord.cs
@@ -85,12 +85,20 @@ namespace Wexflow.Tasks.WorkiomUpdateRecord
                     {
                         if (kvp.Key == linkedFieldId)
                         {
-                            var linkedField = JArray.Parse(kvp.Value.ToString());
-                            foreach (var recordField in linkedField)
+                            if (linkedFieldId == "_id")
                             {
-                                var rId = recordField.Value<string>("_id");
+                                var rId = kvp.Value.ToString();
                                 success &= UpdateRecord(rId, result);
                             }
+                            else {
+                                var linkedField = JArray.Parse(kvp.Value.ToString());
+                                foreach (var recordField in linkedField)
+                                {
+                                    var rId = recordField.Value<string>("_id");
+                                    success &= UpdateRecord(rId, result);
+                                }
+                            }
+                            
                             break;
                         }
                     }


### PR DESCRIPTION
When the `recordIdSourceType` is `dynamic` and if the `linkedFieldId` value
was set to `_id` then set the `recordId` for the record to be updated to the
same ID of the triggering record. This will allow us to update the
triggering record itself.